### PR TITLE
feat: Add GPT response screen

### DIFF
--- a/__mocks__/react-native-geolocation-service.js
+++ b/__mocks__/react-native-geolocation-service.js
@@ -1,0 +1,9 @@
+export default {
+  getCurrentPosition: jest.fn(),
+  watchPosition: jest.fn(),
+  clearWatch: jest.fn(),
+  stopObserving: jest.fn(),
+  requestAuthorization: jest.fn(),
+  setRNConfiguration: jest.fn(),
+  checkPermission: jest.fn(),
+};

--- a/__mocks__/react-native-localize.js
+++ b/__mocks__/react-native-localize.js
@@ -1,0 +1,22 @@
+export const getLocales = () => [
+  { countryCode: 'US', languageTag: 'en-US', languageCode: 'en', isRTL: false },
+  { countryCode: 'KR', languageTag: 'ko-KR', languageCode: 'ko', isRTL: false },
+];
+
+export const findBestAvailableLanguage = () => ({
+  languageTag: 'en-US',
+  isRTL: false,
+});
+
+export const addEventListener = jest.fn();
+export const removeEventListener = jest.fn();
+export const getNumberFormatSettings = jest.fn();
+export const getCalendar = jest.fn();
+export const getCountry = jest.fn();
+export const getCurrencies = jest.fn();
+export const getTemperatureUnit = jest.fn();
+export const getTimeZone = jest.fn();
+export const uses24HourClock = jest.fn();
+export const usesMetricSystem = jest.fn();
+export const usesAutoDateAndTime = jest.fn();
+export const usesAutoTimeZone = jest.fn();

--- a/__mocks__/react-native-webview.js
+++ b/__mocks__/react-native-webview.js
@@ -1,0 +1,6 @@
+import React from 'react';
+const WebView = (props) => {
+  return React.createElement('View', props, React.createElement('Text', null, 'WebView'));
+};
+export { WebView };
+export default WebView;

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,14 @@
 module.exports = {
   preset: 'react-native',
+  transformIgnorePatterns: [
+    'node_modules/(?!(jest-)?react-native|@react-native(-community)?|@react-navigation|react-native-reanimated|react-native-gesture-handler|react-native-screens|react-native-safe-area-context|@react-native-seoul/kakao-login|react-native-vector-icons|react-native-element-dropdown|react-native-geolocation-service|react-native-localize|react-native-webview|i18next|react-i18next)/',
+  ],
+  setupFiles: [
+    "./node_modules/react-native-gesture-handler/jestSetup.js"
+  ],
+  moduleNameMapper: {
+    'react-native-webview': '<rootDir>/__mocks__/react-native-webview.js',
+    'react-native-geolocation-service': '<rootDir>/__mocks__/react-native-geolocation-service.js',
+    'react-native-localize': '<rootDir>/__mocks__/react-native-localize.js',
+  }
 };

--- a/src/screens/GptResponseScreen.tsx
+++ b/src/screens/GptResponseScreen.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { View, Text, StyleSheet, SafeAreaView, ScrollView } from 'react-native';
+import { RouteProp } from '@react-navigation/native';
+import { RootStackParamList } from '../views/RootStack';
+
+type GptResponseScreenRouteProp = RouteProp<RootStackParamList, 'GptResponseScreen'>;
+
+const GptResponseScreen = ({ route }: { route: GptResponseScreenRouteProp }) => {
+  const { duration, companions, styles, moreInfoInput } = route.params;
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <ScrollView contentContainerStyle={styles.scrollContent}>
+        <Text style={styles.title}>춘식이가 선택한 여행 취향</Text>
+        <View style={styles.responseContainer}>
+          <Text style={styles.responseText}>
+            <Text style={styles.label}>여행 기간:</Text> {duration || '선택 안함'}
+            {'\n\n'}
+            <Text style={styles.label}>동행:</Text>{' '}
+            {companions.length > 0 ? companions.join(', ') : '선택 안함'}
+            {'\n\n'}
+            <Text style={styles.label}>여행 스타일:</Text>{' '}
+            {styles.length > 0 ? styles.join(', ') : '선택 안함'}
+            {'\n\n'}
+            <Text style={styles.label}>추가 정보:</Text> {moreInfoInput || '없음'}
+          </Text>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#FFE600',
+  },
+  scrollContent: {
+    padding: 20,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    color: '#333',
+    textAlign: 'center',
+    marginBottom: 20,
+  },
+  responseContainer: {
+    backgroundColor: 'white',
+    borderRadius: 10,
+    padding: 15,
+  },
+  responseText: {
+    fontSize: 16,
+    color: '#333',
+    lineHeight: 24,
+  },
+  label: {
+    fontWeight: 'bold',
+  },
+});
+
+export default GptResponseScreen;

--- a/src/screens/TourInfo.tsx
+++ b/src/screens/TourInfo.tsx
@@ -7,8 +7,8 @@ import {
   Text,
   TouchableOpacity,
 } from 'react-native';
-import { RouteProp } from '@react-navigation/native';
-import { RootStackParamList } from '../views/RootStack';
+import { RouteProp, useNavigation } from '@react-navigation/native';
+import { RootStackParamList, RootStackNavigationProp } from '../views/RootStack';
 import SurveyOption from '../../src/components/component/SurveyOption';
 import SurveySection from '../../src/components/component/SurveySection';
 
@@ -47,7 +47,7 @@ type TourInfoRouteProp = RouteProp<RootStackParamList, 'TourScreen'>;
     ];
 
 const TourScreen = ({ route }: { route: TourInfoRouteProp }) => {
-  
+  const navigation = useNavigation<RootStackNavigationProp>();
   // 상태 관리
   const [selectedDuration, setSelectedDuration] = useState<string | null>(null);
   const [selectedCompanions, setSelectedCompanions] = useState<string[]>([]);
@@ -92,7 +92,7 @@ const TourScreen = ({ route }: { route: TourInfoRouteProp }) => {
     };
     
     console.log('선택된 여행 취향:', preferences);
-    // 여기에 데이터 제출 로직 추가
+    navigation.navigate('GptResponseScreen', preferences);
   };
 
   useEffect(() => {

--- a/src/views/RootStack.tsx
+++ b/src/views/RootStack.tsx
@@ -9,7 +9,8 @@ import Intro from '../screens/Intro';
 import mainScreen from '../screens/MainScreen';
 import AxiosScreen from '../screens/AxiosTet';
 import MapScreen from '../screens/Map';
-import TourScreen from '../screens/TourInfo'
+import TourScreen from '../screens/TourInfo';
+import GptResponseScreen from '../screens/GptResponseScreen';
 import {TextStyle, TouchableOpacity, View, Image,StyleSheet , useWindowDimensions} from 'react-native';
 import { createDrawerNavigator } from '@react-navigation/drawer';
 import DrawerContent from '../components/component/drawercomponet';
@@ -23,6 +24,12 @@ export type RootStackParamList = {
   AxiosScreen: undefined; // Axios 테스트 페이지
   Loading : undefined; // 로딩 페이지
   TourScreen : undefined; // 투어 정보 페이지
+  GptResponseScreen: {
+    duration: string | null;
+    companions: string[];
+    styles: string[];
+    moreInfoInput: string;
+  };
 };
 
 export type RootStackNavigationProp =
@@ -56,6 +63,7 @@ const RootStack = () => (
         <Stack.Screen name="Map"  component={MapScreen} />
         <Stack.Screen name="AxiosScreen" component={AxiosScreen} />
         <Stack.Screen name="TourScreen" component={TourScreen} />
+        <Stack.Screen name="GptResponseScreen" component={GptResponseScreen} />
       </Stack.Navigator>
   
 );


### PR DESCRIPTION
- I created a new screen `GptResponseScreen` to display the results of the travel survey.
- I added the new screen to the root navigation stack.
- I modified the `TourInfo` screen to navigate to the `GptResponseScreen` on form submission, passing the survey data.
- I updated the `GptResponseScreen` to dynamically display the passed survey data.
- I fixed the Jest test suite by mocking several native modules (`react-native-webview`, `react-native-geolocation-service`, `react-native-localize`) that were causing test failures.